### PR TITLE
define USE_LEGACY_NAMESPACE compiler constant in fsproj files

### DIFF
--- a/SliceMap.Tests/SliceMap.Tests.fsproj
+++ b/SliceMap.Tests/SliceMap.Tests.fsproj
@@ -5,6 +5,7 @@
 
     <IsPackable>false</IsPackable>
     <GenerateProgramFile>false</GenerateProgramFile>
+    <DefineConstants>$(DefineConstants);USE_LEGACY_NAMESPACE</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>

--- a/SliceMap.Tests/Tests.fs
+++ b/SliceMap.Tests/Tests.fs
@@ -24,8 +24,11 @@ module Types =
 
     [<Properties(Arbitrary = [| typeof<Types> |] )>]
     module SlicetSetTests =
+        #if USE_LEGACY_NAMESPACE
+        open Flips.SliceMap
+        #else
         open SliceMap
-
+        #endif
 
         [<Property>]
         let ``SliceSet has only distinct values`` (v:List<NonEmptyString>) =
@@ -204,7 +207,11 @@ module Types =
 
     [<Properties(Arbitrary = [| typeof<Types> |] )>]
     module SliceMapTests =
+        #if USE_LEGACY_NAMESPACE
+        open Flips.SliceMap
+        #else
         open SliceMap
+        #endif
 
         [<Property>]
         let ``SliceMap addition is commutative`` (v1:List<(NonEmptyString * Scalar)>) (v2:List<(NonEmptyString * Scalar)>) =
@@ -293,8 +300,15 @@ module Types =
             (x1:NonEmptyString) =
 
             let sm = d |> SMap
+            #if USE_LEGACY_NAMESPACE
+            // todo: see https://github.com/dotnet/fsharp/issues/10544
+            // maybe there is a workaround?
+            let r = sm.[Flips.SliceMap.SliceType.GreaterOrEqual x1]
+            // original code was: 
+            // let r = sm.[GreaterOrEqual x1]
+            #else
             let r = sm.[GreaterOrEqual x1]
-
+            #endif
             for (k1) in r.Keys do
                 Assert.True(k1 >= x1)
 

--- a/SliceMap/SMap.fs
+++ b/SliceMap/SMap.fs
@@ -207,3 +207,25 @@ module SMap =
 
     let containsKey k (m:SMap<_,_>) =
         m.ContainsKey k
+
+#if USE_LEGACY_NAMESPACE
+namespace Flips.SliceMap
+open System
+[<Obsolete("Use types in SliceMap namespace instead of Flips.SliceMap")>]
+type SMap<'Key, 'Value when 'Key : comparison and 'Value : equality> = SliceMap.SMap<'Key,'Value>
+
+[<Obsolete("Use modules in SliceMap namespace instead of Flips.SliceMap")>]
+[<RequireQualifiedAccess>]
+module SMap =
+    
+    let ofSeq = SliceMap.SMap.ofSeq
+    let toSeq = SliceMap.SMap.toSeq
+
+    let ofMap = SliceMap.SMap.ofMap
+    let toMap = SliceMap.SMap.toMap
+    let ofList = SliceMap.SMap.ofList
+    let toList = SliceMap.SMap.toList
+    let ofArray = SliceMap.SMap.ofArray
+    let toArray = SliceMap.SMap.toArray
+    let containsKey = SliceMap.SMap.containsKey
+#endif

--- a/SliceMap/SliceMap.fsproj
+++ b/SliceMap/SliceMap.fsproj
@@ -7,6 +7,7 @@
     <RepositoryUrl>https://github.com/matthewcrews/SliceMap</RepositoryUrl>
     <PackageLicenseFile></PackageLicenseFile>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <DefineConstants>$(DefineConstants);USE_LEGACY_NAMESPACE</DefineConstants>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/SliceMap/SliceSet.fs
+++ b/SliceMap/SliceSet.fs
@@ -354,3 +354,23 @@ module SliceSet =
         | In set -> keys.Intersect (SliceSet set)
         | NotIn set -> keys.Minus (SliceSet set)
         | Where f -> keys.Filter f
+
+#if USE_LEGACY_NAMESPACE
+namespace Flips.SliceMap
+open System
+[<Obsolete("Use types in SliceMap namespace instead of Flips.SliceMap")>]
+type SliceType<'a when 'a : comparison> = SliceMap.SliceType<'a>
+[<Obsolete("Use types in SliceMap namespace instead of Flips.SliceMap");RequireQualifiedAccess>]
+type RankResult = SliceMap.RankResult
+[<Obsolete("Use types in SliceMap namespace instead of Flips.SliceMap")>]
+type SliceSet<'T when 'T : comparison> = SliceMap.SliceSet<'T>
+
+[<Obsolete("Use modules in SliceMap namespace instead of Flips.SliceMap")>]
+[<RequireQualifiedAccess>]
+module SliceSet =
+    let intersect = SliceMap.SliceSet.intersect
+    let toSeq = SliceMap.SliceSet.toSeq
+    let toList = SliceMap.SliceSet.toList
+    let union = SliceMap.SliceSet.union
+    let slice = SliceMap.SliceSet.slice
+#endif


### PR DESCRIPTION
 and define it for SliceSet and SMap.

there is one issue around for DU members.

See https://github.com/dotnet/fsharp/issues/10544

Tests are in "works on my machine" state.