### PR TITLE
[experimental] fable support

### DIFF
--- a/SliceMap.Tests/Program.fs
+++ b/SliceMap.Tests/Program.fs
@@ -1,1 +1,18 @@
-module Program = let [<EntryPoint>] main _ = 0
+open SliceMap
+open Xunit
+
+module Program =
+    let [<EntryPoint>] main _ =
+        #if FABLE_COMPILER
+        // putting a sample here
+        let x = SMap.ofList [for i in 1..5 -> i, i]
+        let isDivisibleBy2 x = x % 2 = 0
+        let ok = x.[Where isDivisibleBy2] =  SMap [(2, 2); (4, 4)]
+        if not ok then
+            failwith $"%A{x.[Where isDivisibleBy2]}\nexpected\n%A{SMap [(2, 2); (4, 4)]}"
+        else
+            printfn "ok!"
+            // python: fails on TryFind.toMap due to Comparer
+            printfn $"{x.[Where isDivisibleBy2]} looks ok :)"
+        #endif
+        0


### PR DESCRIPTION
It is just to get the ball going, and identify potential issues in the different fable targets, not expecting this would get merged and maintained in the same fashion as the .net target.

I only had to make a mock of `System.Memory`, which for now will copy the array when using offsets and length that aren't corresponding to the raw input array.

There is no support for FsCheck in Fable, AFAIK, so I'll consider bringing some of the documentation examples as plain tests.

Right now in the python target:
* printing the slicemap as string is failing, I'm suspecting it is an issue with Fable2Python
*  I needed to bind `length` argument of `Memory` constructor to a local, otherwise Fable2Python gets confused and generates `len(x)` (where x is of type `Memory`).

I'll give a shot at rust by end of the week.